### PR TITLE
Update WebApps URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
           wg:           "Web Applications Working Group",
 
           // URI of the public WG page
-          wgURI:        "http://example.org/really-cool-wg",
+          wgURI:        "http://www.w3.org/2008/webapps/",
 
           // name (without the @w3c.org) of the public mailing to which comments are due
           wgPublicList: "public-webapps",
@@ -60,7 +60,7 @@
           // This is important for Rec-track documents, do not copy a patent URI from a random
           // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
           // Team Contact.
-          wgPatentURI:  "",
+          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/42538/status",
           // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
       };
     </script>


### PR DESCRIPTION
Update WebApps' URL to the group's home page and added the URL for WebApps' patent commitment document.
