### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
           otherLinks: [{
               key: 'Participate',
               data: [{
-                      value: 'We are on Github.',
+                      value: 'We are on GitHub.',
                       href: 'https://github.com/w3c/selection-api'
                   }, {
                       value: 'File a bug.',


### PR DESCRIPTION
This is how the company capitalizes the product name.

(P.S.: Hi @rniwa!)
