### PR TITLE
Add [CEReactions] to Selection's deleteFromDocument()

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,7 +422,7 @@
           </div>
         </dd>
 
-        <dt>void deleteFromDocument()</dt>
+        <dt>[CEReactions] void deleteFromDocument()</dt>
         <dd>
           <p>The method must invoke <dfn><a href="http://dom.spec.whatwg.org/#dom-range-deletecontents"><code>deleteContents()</code></a></dfn> ([[DOM4]])
           on the <a>context object</a>'s <a>range</a> if the <a>context object</a> is not <a>empty</a>.


### PR DESCRIPTION
Since the deleteFromDocument() method can change the DOM in ways that may impact custom elements, it needs to be annotated with the [CEReactions] attribute. This is part of the larger effort at w3c/webcomponents#186. [CEReactions] is defined in https://html.spec.whatwg.org/multipage/scripting.html#cereactions.
