### PR TITLE
Throw exception for removeRange on range that's not in selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,7 +334,8 @@
         <dd>
           <p>The method must make the <a>context object</a> <a>empty</a> by disassociating its <a>range</a>
             if the <a>context object</a>'s <a>range</a> is <var>range</var>.
-            Otherwise, it must do nothing.</p>
+            Otherwise, it must throw a
+            <a href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a>.</p>
         </dd>
 
         <dt><dfn>removeAllRanges</dfn></dt>


### PR DESCRIPTION
This matches Firefox, which was historically the only engine to ever
have a working implementation of removeRange.  WebKit still has none,
Edge seems to be a no-op, and Chrome just added theirs in February.  If
there was only ever one implementation of the feature, the spec should
follow that implementation.

(Firefox doesn't actually throw a DOMException here, it throws a
nonstandard exception.  That's a side point, though.)