### PR TITLE
Remove the <dfn> in Selection interface heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
     </section>
 
     <section data-dfn-for="Selection">
-      <h2><dfn>Selection</dfn> interface</h2>
+      <h2>Selection interface</h2>
       <p><a>Selection</a> interface provides a way to interact with the <a>selection</a>
         associated with each document.
       </p>


### PR DESCRIPTION
This is the cause of the "Duplicate definition of 'selection'" ReSpec
error. The error definition is in
http://w3c.github.io/selection-api/#definition