### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,9 @@
           // URI of the patent status for this WG, for Rec-track documents
           wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/83482/status",
           // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
-          
+
+          testSuiteURI: "https://github.com/w3c/web-platform-tests/tree/master/selection",
+
           otherLinks: [{
               key: 'Participate',
               data: [{


### PR DESCRIPTION
Many other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://w3c.github.io/ServiceWorker/
https://webaudio.github.io/web-audio-api/
https://xhr.spec.whatwg.org/