### PR TITLE
GlobalEventHandlers is a mixin

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,7 @@
           The <code><dfn>GlobalEventHandlers</dfn></code> interface is defined in [[!HTML]].
         </p>
         <pre class="idl">
-          partial interface GlobalEventHandlers {
+          partial interface mixin GlobalEventHandlers {
             attribute EventHandler onselectstart;
             attribute EventHandler onselectionchange;
           };


### PR DESCRIPTION
... and thus it should be only extended by `partial interface mixin`s.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/selection-api/pull/100.html" title="Last updated on Nov 8, 2018, 5:00 AM GMT (ccf7108)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/100/30dcb38...saschanaz:ccf7108.html" title="Last updated on Nov 8, 2018, 5:00 AM GMT (ccf7108)">Diff</a>