### PR TITLE
Editorial: Remove redefinition of `editing host`. Relink to its HTML spec definition 

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,8 +517,8 @@
             <li>If <var>anchorOffset</var> is longer than
             <var>anchorNode</var>'s [=Node/length=] or if
             <var>focusOffset</var> is longer than <var>focusNode</var>'s
-            [=Node/length=], throw an {{IndexSizeError}}
-            exception and abort these steps.
+            [=Node/length=], throw an {{IndexSizeError}} exception and abort
+            these steps.
             </li>
             <li>If the [=tree/root=]s of <var>anchorNode</var> or
             <var>focusNode</var> are not the <a>document</a> associated with
@@ -558,8 +558,7 @@
             associated with the <a>context object</a>, abort these steps.
             </li>
             <li>Let <var>newRange</var> be a new <a>range</a> and
-            <var>nodeLength</var> be the [=Node/length=] of <var>
-              node</var>.
+            <var>nodeLength</var> be the [=Node/length=] of <var>node</var>.
             </li>
             <li>Set <var>newRange</var>'s [=range/start=] to (<var>node</var>,
             <code>0</code>).

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
       <p>
         This one <a>selection</a> must be shared by all the content of the
         <a>document</a> (though not by nested <a>documents</a>), including any
-        editing hosts in the document. <dfn>Editing hosts</dfn> that are not
+        editing hosts in the document. Editing hosts that are not
         inside a <a>document</a> cannot have a <a>selection</a>
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
       <p>
         This one <a>selection</a> must be shared by all the content of the
         <a>document</a> (though not by nested <a>documents</a>), including any
-        editing hosts in the document. Editing hosts that are not
+        [=editing hosts=] in the document. [=Editing hosts=] that are not
         inside a <a>document</a> cannot have a <a>selection</a>
       </p>
       <p>


### PR DESCRIPTION
Hi! I recently [imported](https://github.com/whatwg/html/pull/5253/) the definition of `editing host` from the execCommand spec to the HTML spec.

@marcoscaceres mentioned that the next steps are to find other specs that currently use `editing host` and to do the following:
1. remove any redefinitions
2. link the singular and plural forms of `editing host` to the [current definition in the HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#editing-host).

In this PR, I have :
1. removed a redefinition of `editing host` in `index.html`.
2. linked `editing host` to the current definition in the HTML spec.

Similar PRs related to the `editing host` import:
* [PR 109 - Clipboard APIs](https://github.com/w3c/clipboard-apis/pull/109)
* [PR 108 - Input Events](https://github.com/w3c/input-events/pull/108)

Thank you!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janiceshiu/selection-api/pull/119.html" title="Last updated on Feb 24, 2020, 5:58 AM UTC (f42ec0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/119/fef1495...janiceshiu:f42ec0a.html" title="Last updated on Feb 24, 2020, 5:58 AM UTC (f42ec0a)">Diff</a>