### PR TITLE
Fix selectAllChildren to use child count

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,13 +555,13 @@
             associated with [=this=], abort these steps.
             </li>
             <li>Let <var>newRange</var> be a new <a>range</a> and
-            <var>nodeLength</var> be the [=Node/length=] of <var>node</var>.
+            <var>childCount</var> be the number of [=tree/children=] of <var>node</var>.
             </li>
             <li>Set <var>newRange</var>'s [=range/start=] to (<var>node</var>,
             <code>0</code>).
             </li>
             <li>Set <var>newRange</var>'s [=range/end=] to (<var>node</var>,
-            <var>nodeLength</var>).
+            <var>childCount</var>).
             </li>
             <li>Set [=this=]'s <a>range</a> to
             <var>newRange</var>.


### PR DESCRIPTION
It matches the actual browser behavior.

Closes #125 

The following tasks have been completed:

 * [x] Modified Web platform tests (link to pull request): Already written as such https://github.com/web-platform-tests/wpt/blob/7b0ebaccc62b566a1965396e5be7bb2bc06f841f/selection/selectAllChildren.html#L53

Implementation commitment:

 * [x] WebKit https://webkit-search.igalia.com/webkit/rev/267a25a31211b30330b892dafd40b1ecf8c69505/Source/WebCore/page/DOMSelection.cpp#443
 * [x] Chromium https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/dom_selection.cc;l=755;drc=d33f201ddf980f5e4d3dd13aebf6166a7aaf5242
 * [x] Gecko https://searchfox.org/mozilla-central/rev/2c991232499e826e46f9d976eb653817340ba389/dom/base/Selection.cpp#2675


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/pull/136.html" title="Last updated on Jun 10, 2021, 2:50 PM UTC (fc5830a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/136/b3e79ef...fc5830a.html" title="Last updated on Jun 10, 2021, 2:50 PM UTC (fc5830a)">Diff</a>