### PR TITLE
Fire selectionchange on input/textarea elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,6 +858,13 @@
           bubble and is not cancelable, at the <a>document</a> associated with
           the <a>selection</a>.
         </p>
+        <p>
+          When an [^input^] or [^textarea^] element provide a text selection and
+          its selection changes (in either extent or [=direction=]), the user
+          agent must [=queue a task=] to [=fire an event=] with the name
+          <code>selectionchange</code>, which does bubble but is not cancelable,
+          at the element.
+        </p>
       </section>
     </section>
     <section id='conformance'>


### PR DESCRIPTION
Closes (partially) #53, since this only covers `selectionchange` without `selectstart` because of no implementation.

Closes #75.

This follows [the suggestion from @smaug----](https://github.com/w3c/selection-api/issues/53#issuecomment-692672383) - to bubble up from text controls to `document`, since it allows to easily detect which text control fired it.

([`document.activeElement` can be used in some cases](https://github.com/w3c/selection-api/issues/53#issuecomment-677500484) to detect the source, but it's not always useful since it can be fired without focusing, e.g. through `.setSelectionRange()`.)

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request) - 

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=) @tkent-google?
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1648944) @smaug---- @masayuki-nakano @annevk


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/pull/141.html" title="Last updated on Jun 23, 2021, 7:32 AM UTC (bc70136)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/141/b2f91fb...bc70136.html" title="Last updated on Jun 23, 2021, 7:32 AM UTC (bc70136)">Diff</a>