### PR TITLE
Remove compat note for getRangeAt()

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/selection",
         github: "w3c/selection-api",
         xref: "web-platform",
+        testSuiteURI: "https://wpt.fyi/results/selection/",
       };
     </script>
   </head>
@@ -283,7 +284,7 @@
           <dfn>getRangeAt()</dfn> method
         </dt>
         <dd>
-          <p>
+          <p data-tests="getRangeAt.html">
             The method must throw an {{IndexSizeError}} exception if
             <var>index</var> is not <code>0</code>, or if [=this=] is
             <a>empty</a>. Otherwise, it must return a reference to (not a copy
@@ -295,11 +296,6 @@
             particular, <code>getSelection().getRangeAt(0) ===
             getSelection().getRangeAt(0)</code> evaluates to <code>true</code>
             if the <a>selection</a> is not <a>empty</a>.
-          </p>
-          <p class="note">
-            IE9 and Firefox 4.0 return the same object every time, as the spec
-            says. Chrome 12 dev and Opera 11.10 return a different object every
-            time.
           </p>
         </dd>
         <dt>


### PR DESCRIPTION
It conflicts with its previous note (the spec does *not* say it should return the same object every time), and also is outdated as Chrome now follows the spec.

The following tasks have been completed:

 * [x] Modified Web platform tests: https://github.com/web-platform-tests/wpt/pull/29773

Implementation commitment: (N/A, no behavior change)

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/pull/144.html" title="Last updated on Jul 24, 2021, 12:19 AM UTC (3e1da33)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/144/df47621...3e1da33.html" title="Last updated on Jul 24, 2021, 12:19 AM UTC (3e1da33)">Diff</a>