### PR TITLE
Align description of events with DOM suggested phrasing

### DIFF
--- a/index.html
+++ b/index.html
@@ -820,13 +820,13 @@
       </p>
       <section>
         <h3>
-          <code><dfn>selectstart</dfn></code> event
+          <code><dfn data-dfn-type=event>selectstart</dfn></code> event
         </h3>
         <p>
           When the user agent is about to associate a new range
           <var>newRange</var> to the <a>selection</a> in response to a user
-          initiated action, the user agent must <a>fire an event</a> with the
-          name <code>selectstart</code>, which bubbles and is cancelable, at
+          initiated action, the user agent must <a>fire an event</a> named
+          <code>selectstart</code>, which bubbles and is cancelable, at
           the [=boundary point/node=] associated with the <a>boundary point</a>
           of <var>newRange</var>'s [=range/start=] prior to changing the
           selection if the <a>selection</a> was previously <a>empty</a> or the
@@ -843,22 +843,22 @@
       </section>
       <section>
         <h3>
-          <code><dfn>selectionchange</dfn></code> event
+          <code><dfn data-dfn-type=event>selectionchange</dfn></code> event
         </h3>
         <p>
           When the <a>selection</a> is dissociated with its <a>range</a>,
           associated with a new <a>range</a> or the associated <a>range</a>'s
           <a>boundary point</a> is mutated either by the user or the content
           script, the user agent must <a>queue a task</a> to <a>fire an
-          event</a> with the name <code>selectionchange</code>, which does not
+          event</a> named <code>selectionchange</code>, which does not
           bubble and is not cancelable, at the <a>document</a> associated with
           the <a>selection</a>.
         </p>
         <p>
           When an [^input^] or [^textarea^] element provide a text selection
           and its selection changes (in either extent or [=direction=]), the
-          user agent must [=queue a task=] to [=fire an event=] with the name
-          <code>selectionchange</code>, which does bubble but is not
+          user agent must [=queue a task=] to [=fire an event=] named
+          <code>selectionchange</code>, which bubbles but is not
           cancelable, at the element.
         </p>
       </section>


### PR DESCRIPTION
see https://dom.spec.whatwg.org/#firing-events-example

this helps with automated extraction of data from specs


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/selection-api/pull/148.html" title="Last updated on Jul 13, 2022, 1:10 AM UTC (7b5ada4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/148/721b716...dontcallmedom:7b5ada4.html" title="Last updated on Jul 13, 2022, 1:10 AM UTC (7b5ada4)">Diff</a>