### PR TITLE
Fix the definition of containsNode() method when allowPartialContainment is true.

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,10 +624,10 @@
             If <var>allowPartialContainment</var> is <code>true</code>, the
             method must return <code>true</code> if and only if [=range/start=]
             of its <a>range</a> is [=boundary point/before=] or visually
-            equivalent to the first <a>boundary point</a> in the
-            <var>node</var> <strong>or</strong> [=range/end=] of its
+            equivalent to the last <a>boundary point</a> in the
+            <var>node</var> <strong>and</strong> [=range/end=] of its
             <a>range</a> is [=boundary point/after=] or visually equivalent to
-            the last <a>boundary point</a> in the <var>node</var>.
+            the first <a>boundary point</a> in the <var>node</var>.
           </p>
         </dd>
         <dt>


### PR DESCRIPTION
Closes the issue #116.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/pull/152.html" title="Last updated on Jul 12, 2022, 11:01 PM UTC (8d61dad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/152/38f7f8c...8d61dad.html" title="Last updated on Jul 12, 2022, 11:01 PM UTC (8d61dad)">Diff</a>