### PR TITLE
Clarify that the user interaction task source is used for selectionchange event

### DIFF
--- a/index.html
+++ b/index.html
@@ -838,18 +838,18 @@
         <p>
           When the <a>selection</a> is dissociated with its <a>range</a>,
           associated with a new <a>range</a> or the associated <a>range</a>'s
-          <a>boundary point</a> is mutated either by the user or the content
-          script, the user agent must <a>queue a task</a> to <a>fire an
-          event</a> named <code>selectionchange</code>, which does not
-          bubble and is not cancelable, at the <a>document</a> associated with
-          the <a>selection</a>.
+          <a>boundary point</a> is mutated either by the user or the content script,
+          the user agent must <a>queue a task</a> on the <a>user interaction task source</a>
+          to <a>fire an event</a> named <code>selectionchange</code>,
+          which does not bubble and is not cancelable,
+          at the <a>document</a> associated with the <a>selection</a>.
         </p>
         <p>
           When an [^input^] or [^textarea^] element provide a text selection
-          and its selection changes (in either extent or [=direction=]), the
-          user agent must [=queue a task=] to [=fire an event=] named
-          <code>selectionchange</code>, which bubbles but is not
-          cancelable, at the element.
+          and its selection changes (in either extent or [=direction=]),
+          the user agent must <a>queue a task</a> on the <a>user interaction task source</a>
+          to <a>fire an event</a> named <code>selectionchange</code>,
+          which bubbles but is not cancelable, at the element.
         </p>
       </section>
     </section>


### PR DESCRIPTION
Closes the issue #117.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/pull/155.html" title="Last updated on Jul 13, 2022, 2:26 AM UTC (9e869be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/155/fff9e05...9e869be.html" title="Last updated on Jul 13, 2022, 2:26 AM UTC (9e869be)">Diff</a>