### PR TITLE
Remove the stray sentence that editing hosts outside a document cannot have a selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,8 +109,7 @@
       <p>
         This one <a>selection</a> must be shared by all the content of the
         <a>document</a> (though not by nested <a>documents</a>), including any
-        [=editing hosts=] in the document. [=Editing hosts=] that are not
-        inside a <a>document</a> cannot have a <a>selection</a>.
+        [=editing hosts=] in the document.</a>.
       </p>
       <p>
         Each <a>selection</a> can be associated with a single <a>range</a>.


### PR DESCRIPTION
Preceeding paragraphs make it clear that selection is a concept of a document and nothing else.

Closes issue #1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/pull/156.html" title="Last updated on Jul 13, 2022, 3:38 AM UTC (0a6a47b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/156/5fea97d...0a6a47b.html" title="Last updated on Jul 13, 2022, 3:38 AM UTC (0a6a47b)">Diff</a>