### PR TITLE
Change getComposedRanges to have options as input

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,7 +415,7 @@
             <li>While <var>startNode</var> is a [=node=],
             <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and
             <var>startNode</var>'s [=tree/root=] is not a [=shadow-including
-            inclusive ancestor=] of any of <var>shadowRoots</var>, repeat these
+            inclusive ancestor=] of any of <var>options.shadowRoots</var>, repeat these
             steps:
               <ol>
                 <li>Set <var>startOffset</var> to [=tree/index=] of
@@ -433,7 +433,7 @@
             <li>While <var>endNode</var> is a [=node=], <var>endNode</var>'s
             [=tree/root=] is a [=shadow root=], and <var>endNode</var>'s
             [=tree/root=] is not a [=shadow-including inclusive ancestor=] of
-            any of <var>shadowRoots</var>, repeat these steps:
+            any of <var>options.shadowRoots</var>, repeat these steps:
               <ol>
                 <li>Set <var>endOffset</var> to [=tree/index=] of
                 <var>endNode</var>'s [=tree/root=]'s [=host=] plus 1.

--- a/index.html
+++ b/index.html
@@ -415,7 +415,8 @@
             <li>While <var>startNode</var> is a [=node=],
             <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and
             <var>startNode</var>'s [=tree/root=] is not a [=shadow-including
-            inclusive ancestor=] of any of <var>options.shadowRoots</var>, repeat these
+            inclusive ancestor=] of any of <var>options</var>
+            ["{{GetComposedRangesOptions/shadowRoots}}"], repeat these
             steps:
               <ol>
                 <li>Set <var>startOffset</var> to [=tree/index=] of
@@ -433,7 +434,8 @@
             <li>While <var>endNode</var> is a [=node=], <var>endNode</var>'s
             [=tree/root=] is a [=shadow root=], and <var>endNode</var>'s
             [=tree/root=] is not a [=shadow-including inclusive ancestor=] of
-            any of <var>options.shadowRoots</var>, repeat these steps:
+            any of <var>options</var>
+            ["{{GetComposedRangesOptions/shadowRoots}}"], repeat these steps:
               <ol>
                 <li>Set <var>endOffset</var> to [=tree/index=] of
                 <var>endNode</var>'s [=tree/root=]'s [=host=] plus 1.

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
           undefined removeRange(Range range);
           undefined removeAllRanges();
           undefined empty();
-          sequence&lt;StaticRange&gt; getComposedRanges(ShadowRoot... shadowRoots);
+          sequence&lt;StaticRange&gt; getComposedRanges(optional GetComposedRangesOptions options = {});
           undefined collapse(Node? node, optional unsigned long offset = 0);
           undefined setPosition(Node? node, optional unsigned long offset = 0);
           undefined collapseToStart();
@@ -222,6 +222,10 @@
           [CEReactions] undefined deleteFromDocument();
           boolean containsNode(Node node, optional boolean allowPartialContainment = false);
           stringifier;
+        };
+
+        dictionary GetComposedRangesOptions {
+          sequence<ShadowRoot> shadowRoots = [];
         };
       </pre>
       <dl>

--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
         };
 
         dictionary GetComposedRangesOptions {
-          sequence<ShadowRoot> shadowRoots = [];
+          sequence&lt;ShadowRoot&gt; shadowRoots = [];
         };
       </pre>
       <dl>

--- a/index.html
+++ b/index.html
@@ -415,9 +415,9 @@
             <li>While <var>startNode</var> is a [=node=],
             <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and
             <var>startNode</var>'s [=tree/root=] is not a [=shadow-including
-            inclusive ancestor=] of any of <var>options</var>
-            ["{{GetComposedRangesOptions/shadowRoots}}"], repeat these
-            steps:
+            inclusive ancestor=] of any of
+            <var>options</var>["{{GetComposedRangesOptions/shadowRoots}}"],
+            repeat these steps:
               <ol>
                 <li>Set <var>startOffset</var> to [=tree/index=] of
                 <var>startNode</var>'s [=tree/root=]'s [=host=].
@@ -434,8 +434,9 @@
             <li>While <var>endNode</var> is a [=node=], <var>endNode</var>'s
             [=tree/root=] is a [=shadow root=], and <var>endNode</var>'s
             [=tree/root=] is not a [=shadow-including inclusive ancestor=] of
-            any of <var>options</var>
-            ["{{GetComposedRangesOptions/shadowRoots}}"], repeat these steps:
+            any of
+            <var>options</var>["{{GetComposedRangesOptions/shadowRoots}}"],
+            repeat these steps:
               <ol>
                 <li>Set <var>endOffset</var> to [=tree/index=] of
                 <var>endNode</var>'s [=tree/root=]'s [=host=] plus 1.


### PR DESCRIPTION
Closes #176

Implementation commitment:

 * [x] WebKit (https://github.com/w3c/selection-api/issues/176#issuecomment-2362070387) (caveat web compat)
 * [x] Chromium (https://issues.chromium.org/issues/355577223, https://github.com/w3c/selection-api/issues/176#issuecomment-2118432134)
 * [x] Gecko (https://github.com/w3c/selection-api/issues/176#issuecomment-2256467136)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dizhang168/selection-api/pull/331.html" title="Last updated on Sep 30, 2024, 3:19 PM UTC (4efbda8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/331/45f8fe8...dizhang168:4efbda8.html" title="Last updated on Sep 30, 2024, 3:19 PM UTC (4efbda8)">Diff</a>