### PR TITLE
Throw InvalidNodeTypeError for doctype more eagerly

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,6 +465,9 @@
             <li>If <var>node</var> is null, this method must behave identically
             as <code>removeAllRanges()</code> and abort these steps.
             </li>
+            <li>If <var>node</var> is a {{DocumentType}}, throw an
+                {{InvalidNodeTypeError}} exception and abort these steps.
+            </li>
             <li>The method must throw an {{IndexSizeError}} exception if <var>
               offset</var> is longer than <var>node</var>'s [=Node/length=] and
               abort these steps.
@@ -625,6 +628,9 @@
             The method must follow these steps:
           </p>
           <ol>
+            <li>If <var>node</var> is a {{DocumentType}}, throw an
+                {{InvalidNodeTypeError}} exception and abort these steps.
+            </li>
             <li>If <var>node</var>'s [=tree/root=] is not the <a>document</a>
             associated with [=this=], abort these steps.
             </li>


### PR DESCRIPTION
This matches how major engines behave and is covered by multiple tests in WPT already.

Closes #118.

Supersedes #86.

Note: I didn't touch `setBaseAndExtent` here, since Gecko doesn’t throw on doctype but WebKit and Blink do.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/awesomekling/selection-api/pull/342.html" title="Last updated on Nov 16, 2024, 10:18 AM UTC (2679812)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/342/97a072c...awesomekling:2679812.html" title="Last updated on Nov 16, 2024, 10:18 AM UTC (2679812)">Diff</a>