### PR TITLE
Change Selection to be associated with a composed live range

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,8 @@
         [=editing hosts=] in the <a>document</a>.
       </p>
       <p>
-        Each <a>selection</a> can be associated with a single <a>range</a>.
+        Each <a>selection</a> can be associated with a single
+        <a href="TODO">composed live range</a> <dfn>range</dfn>.
         When there is no <a>range</a> associated with the <a>selection</a>, the
         selection is <dfn>empty</dfn>. The selection must be initially
         <a>empty</a>.
@@ -127,6 +128,20 @@
         dev do not. We follow Gecko/WebKit, because it lessens the chance of
         getRangeAt(0) throwing.
       </p>
+      <p>To <dfn>reset the range</dfn> of [=this=], given the
+       <a>boundary point</a> <var>start</var> and <a>boundary point</a>
+       <var>end</var>, run these steps:
+      </p>
+      <ol>
+       <li>Let <var>newCachedRange</var> be a new {{Range}} object.</li>
+       <li>[=Range/Set the start=] of <var>newCachedRange</var> to <var>start</var>.
+       </li>
+       <li>[=Range/Set the end=] of <var>newCachedRange</var> to <var>end</var>.</li>
+       <li>Let <var>newRange</var> be a new <a href="TODO">composed live range</a>
+       whose [=Range/start=] is <var>start</var>, [=Range/end=] is <var>end</var>
+       and <var>cached live range</var> is <var>newCachedRange</var>.</li>
+       <li>Set [=this=]'s <a>range</a> to be <var>newRange</var>.</li>
+     </ol>
       <p>
         Once a <a>selection</a> is associated with a given <a>range</a>, it
         must continue to be associated with that same <a>range</a> until this
@@ -167,13 +182,14 @@
         <a>selection</a> must be preserved.
       </p>
       <p>
-        Each <a>selection</a>s also have an <dfn>anchor</dfn> and a
+        Each <a>selection</a> also has an <dfn>anchor</dfn> and a
         <dfn>focus</dfn>. If the <a>selection</a>'s <a>range</a> is null, its
         <a>anchor</a> and <a>focus</a> are both null. If the <a>selection</a>'s
         <a>range</a> is not null and its <a>direction</a> is <a>forwards</a>,
-        its <a>anchor</a> is the <a>range</a>'s [=range/start=], and its
-        <a>focus</a> is the [=range/end=]. Otherwise, its <a>focus</a> is the
-        [=range/start=] and its <a>anchor</a> is the [=range/end=].
+        its <a>anchor</a> is the <a>range</a>'s cached live range's
+        [=range/start=], and its <a>focus</a> is the [=range/end=]. Otherwise,
+        its <a>focus</a> is the [=range/start=] and its <a>anchor</a> is the
+        [=range/end=].
       </p>
       <p class="note">
         <a>anchor</a> and <a>focus</a> of <a>selection</a> need not to be in
@@ -320,7 +336,7 @@
             <var>index</var> is not <code>0</code>, or if [=this=] is
             <a>empty</a> or either <a>focus</a> or <a>anchor</a> is not in the
             [=document tree=]. Otherwise, it must return a reference to (not a
-            copy of) [=this=]'s <a>range</a>.
+            copy of) [=this=]'s <a>range</a>'s cached live range.
           </p>
           <p class="note">
             Thus subsequent calls of this method returns the same <a>range</a>
@@ -345,8 +361,8 @@
             <li>If <code>rangeCount</code> is not <code>0</code>, abort these
             steps.
             </li>
-            <li>Set [=this=]'s range to <var>range</var> by a strong reference
-            (not by making a copy).
+            <li>Set [=this=]'s range's cached live range to <var>range</var> by
+            a strong reference (not by making a copy).
             </li>
           </ol>
           <p class="note">
@@ -379,8 +395,8 @@
         <dd>
           <p>
             The method must make [=this=] <a>empty</a> by disassociating its
-            <a>range</a> if [=this=]'s <a>range</a> is <var>range</var>.
-            Otherwise, it must throw a {{NotFoundError}}.
+            <a>range</a> if [=this=]'s <a>range</a>'s cached live range is
+            <var>range</var>. Otherwise, it must throw a {{NotFoundError}}.
           </p>
         </dd>
         <dt>
@@ -476,13 +492,8 @@
             [=shadow-including inclusive ancestor=] of <var>node</var>, abort
             these steps.
             </li>
-            <li>Otherwise, let <var>newRange</var> be a new <a>range</a>.
-            </li>
-            <li>[=Range/Set the start=] the [=range/start=] and the
-            [=range/end=] of <var>newRange</var> to (<var>node</var>,
-            <var>offset</var>).
-            </li>
-            <li>Set [=this=]'s <a>range</a> to <var>newRange</var>.
+            <li>Otherwise, <a>reset the range</a> with (<var>node</var>,
+            <var>offset</var>) and (<var>node</var>, <var>offset</var>).
             </li>
           </ol>
         </dd>
@@ -500,13 +511,17 @@
         </dt>
         <dd>
           <p>
-            The method must throw {{InvalidStateError}} exception if the
-            [=this=] is <a>empty</a>. Otherwise, it must create a new
-            <a>range</a>, [=Range/set the start=] both its [=range/start=] and
-            [=range/end=] to the [=range/start=] of [=this=]'s <a>range</a>,
-            and then set [=this=]'s <a>range</a> to the newly-created
-            <a>range</a>.
+           The method must follow these steps:
           </p>
+          <ol>
+           <li>If [=this=] is <a>empty</a>, throw an {{InvalidStateError}}
+           exception and abort these steps.
+           </li>
+           <li>Let <var>bp</var> be the [=Range/start=] of [=this=]'s <a>range</a>.
+           </li>
+           <li><a>Reset the range</a> with <var>bp</var> and <var>bp</var>.
+           </li>
+         </ol>
           <p class="note">
             For collapseToStart/End, IE9 mutates the existing range, while
             Firefox 9.0a2 and Chrome 15 dev replace it with a new one. The spec
@@ -518,13 +533,18 @@
           <dfn>collapseToEnd()</dfn> method
         </dt>
         <dd>
-          <p>
-            The method must throw {{InvalidStateError}} exception if the
-            [=this=] is <a>empty</a>. Otherwise, it must create a new
-            <a>range</a>, [=Range/set the start=] both its [=range/start=] and
-            [=range/end=] to the [=range/end=] of [=this=]'s <a>range</a>, and
-            then set [=this=]'s <a>range</a> to the newly-created <a>range</a>.
-          </p>
+         <p>
+          The method must follow these steps:
+         </p>
+         <ol>
+          <li>If [=this=] is <a>empty</a>, throw an {{InvalidStateError}}
+          exception and abort these steps.
+          </li>
+          <li>Let <var>bp</var> be the [=Range/end=] of [=this=]'s <a>range</a>.
+          </li>
+          <li><a>Reset the range</a> with <var>bp</var> and <var>bp</var>.
+          </li>
+        </ol>
         </dd>
         <dt>
           <dfn>extend()</dfn> method
@@ -546,24 +566,18 @@
             <var>newFocus</var> be the <a>boundary point</a> (<var>node</var>,
             <var>offset</var>).
             </li>
-            <li>Let <var>newRange</var> be a new <a>range</a>.
-            </li>
-            <li>If <var>node</var>'s [=tree/root=] is not the same as the
-            [=this=]'s <a>range</a>'s [=tree/root=], [=Range/set the start=]
-            <var>newRange</var>'s [=range/start=] and [=range/end=] to
-            <var>newFocus</var>.
+            <li>If <var>node</var>'s [=tree/root=] is not the same as
+            [=this=]'s <a>range</a>'s [=tree/root=], <a>reset the range</a> with
+            <var>newFocus</var> and <var>newFocus</var>.
             </li>
             <li>Otherwise, if <var>oldAnchor</var> is [=boundary point/before=]
-            or equal to <var>newFocus</var>, [=Range/set the start=]
-            <var>newRange</var>'s [=range/start=] to <var>oldAnchor</var>, then
-            set its [=range/end=] to <var>newFocus</var>.
+            or equal to <var>newFocus</var>, <a>reset the range</a>
+            with <var>oldAnchor</var> and <var>newFocus</var>.
             </li>
-            <li>Otherwise, [=Range/set the start=] <var>newRange</var>'s
-            [=range/start=] to <var>newFocus</var>, then set its [=range/end=]
-            to <var>oldAnchor</var>.
+            <li>Otherwise, <a>reset the range</a> with <var>newFocus</var>
+            and <var>oldAnchor</var>.
             </li>
-            <li>Set [=this=]'s <a>range</a> to <var>newRange</var>.
-            </li>
+
             <li>If <var>newFocus</var> is [=boundary point/before=]
             <var>oldAnchor</var>, set [=this=]'s <a>direction</a> to
             <a>backwards</a>. Otherwise, set it to <a>forwards</a>.
@@ -604,15 +618,10 @@
             <var>focus</var> be the <a>boundary point</a>
             (<var>focusNode</var>, <var>focusOffset</var>).
             </li>
-            <li>Let <var>newRange</var> be a new <a>range</a>.
-            </li>
             <li>If <var>anchor</var> is [=boundary point/before=]
-            <var>focus</var>, [=Range/set the start=] the <var>newRange</var>'s
-            [=range/start=] to <var>anchor</var> and its [=range/end=] to <var>
-              focus</var>. Otherwise, [=Range/set the start=] them to
-              <var>focus</var> and <var>anchor</var> respectively.
-            </li>
-            <li>Set [=this=]'s <a>range</a> to <var>newRange</var>.
+            <var>focus</var>, <a>reset the range</a> with <var>anchor</var> and
+            <var>focus</var>. Otherwise, <a>reset the range</a> with
+            <var>focus</var> and <var>anchor</var>.
             </li>
             <li>If <var>focus</var> is [=boundary point/before=]
             <var>anchor</var>, set [=this=]'s <a>direction</a> to
@@ -634,17 +643,11 @@
             <li>If <var>node</var>'s [=tree/root=] is not the <a>document</a>
             associated with [=this=], abort these steps.
             </li>
-            <li>Let <var>newRange</var> be a new <a>range</a> and
-            <var>childCount</var> be the number of [=tree/children=] of
+            <li>Let <var>childCount</var> be the number of [=tree/children=] of
             <var>node</var>.
             </li>
-            <li>Set <var>newRange</var>'s [=range/start=] to (<var>node</var>,
-            <code>0</code>).
-            </li>
-            <li>Set <var>newRange</var>'s [=range/end=] to (<var>node</var>,
-            <var>childCount</var>).
-            </li>
-            <li>Set [=this=]'s <a>range</a> to <var>newRange</var>.
+            <li><a>Reset the range</a> with (<var>node</var>, <code>0</code>)
+            and (<var>node</var>, <var>childCount</var>).
             </li>
             <li>Set [=this=]'s <a>direction</a> to <var>forwards</var>.
             </li>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
       </p>
       <p>
         Each <a>selection</a> can be associated with a single
-        <a href="TODO">composed live range</a> <dfn>range</dfn>.
+        <a href="TODO">composed selection range</a> <dfn>range</dfn>.
         When there is no <a>range</a> associated with the <a>selection</a>, the
         selection is <dfn>empty</dfn>. The selection must be initially
         <a>empty</a>.
@@ -128,19 +128,30 @@
         dev do not. We follow Gecko/WebKit, because it lessens the chance of
         getRangeAt(0) throwing.
       </p>
-      <p>To <dfn>reset the range</dfn> of [=this=], given the
+      <p>To <dfn>set the composed selection range</dfn> of [=this=], given the
        <a>boundary point</a> <var>start</var> and <a>boundary point</a>
        <var>end</var>, run these steps:
       </p>
       <ol>
-       <li>Let <var>newCachedRange</var> be a new {{Range}} object.</li>
-       <li>[=Range/Set the start=] of <var>newCachedRange</var> to <var>start</var>.
+       <li>Let <var>liveRange</var> be a new {{Range/}} object.</li>
+       <li>[=Range/Set the start=] of <var>liveRange</var> to <var>start</var>.
        </li>
-       <li>[=Range/Set the end=] of <var>newCachedRange</var> to <var>end</var>.</li>
-       <li>Let <var>newRange</var> be a new <a href="TODO">composed live range</a>
-       whose [=Range/start=] is <var>start</var>, [=Range/end=] is <var>end</var>
-       and <var>cached live range</var> is <var>newCachedRange</var>.</li>
-       <li>Set [=this=]'s <a>range</a> to be <var>newRange</var>.</li>
+       <li>[=Range/Set the end=] of <var>liveRange</var> to <var>end</var>.</li>
+       <li>Let <var>composedRange</var> be a new
+       <a href="">composed selection range</a>
+       whose [=Range/start=] is <var>start</var>, [=Range/end=] is
+       <var>end</var> and <var>legacy selection range</var> is
+       <var>liveRange</var>.</li>
+       <p class="note">
+        While the above steps might look identical, <var>liveRange</var> and
+        <var>composedRange</var> could end up in very different states. The
+        <var>liveRange</var> follows [=Range/set the start=] and
+        [=Range/set the end=] algorithms, which will collapse in cross-root
+        cases. On the other hand, <var>composedRange</var> is set directly
+        without any collapsing logic.
+       </p>
+       <li>Set [=this=]'s <a href="">composed selection range</a> to
+       <var>composedRange</var>.</li>
      </ol>
       <p>
         Once a <a>selection</a> is associated with a given <a>range</a>, it
@@ -186,7 +197,7 @@
         <dfn>focus</dfn>. If the <a>selection</a>'s <a>range</a> is null, its
         <a>anchor</a> and <a>focus</a> are both null. If the <a>selection</a>'s
         <a>range</a> is not null and its <a>direction</a> is <a>forwards</a>,
-        its <a>anchor</a> is the <a>range</a>'s cached live range's
+        its <a>anchor</a> is the <a>range</a>'s legacy selection range's
         [=range/start=], and its <a>focus</a> is the [=range/end=]. Otherwise,
         its <a>focus</a> is the [=range/start=] and its <a>anchor</a> is the
         [=range/end=].
@@ -336,7 +347,7 @@
             <var>index</var> is not <code>0</code>, or if [=this=] is
             <a>empty</a> or either <a>focus</a> or <a>anchor</a> is not in the
             [=document tree=]. Otherwise, it must return a reference to (not a
-            copy of) [=this=]'s <a>range</a>'s cached live range.
+            copy of) [=this=]'s <a>range</a>'s legacy selection range.
           </p>
           <p class="note">
             Thus subsequent calls of this method returns the same <a>range</a>
@@ -361,8 +372,8 @@
             <li>If <code>rangeCount</code> is not <code>0</code>, abort these
             steps.
             </li>
-            <li>Set [=this=]'s range's cached live range to <var>range</var> by
-            a strong reference (not by making a copy).
+            <li>Set [=this=]'s range's legacy selection range to
+             <var>range</var> by a strong reference (not by making a copy).
             </li>
           </ol>
           <p class="note">
@@ -395,7 +406,7 @@
         <dd>
           <p>
             The method must make [=this=] <a>empty</a> by disassociating its
-            <a>range</a> if [=this=]'s <a>range</a>'s cached live range is
+            <a>range</a> if [=this=]'s <a>range</a>'s legacy selection range is
             <var>range</var>. Otherwise, it must throw a {{NotFoundError}}.
           </p>
         </dd>
@@ -492,8 +503,9 @@
             [=shadow-including inclusive ancestor=] of <var>node</var>, abort
             these steps.
             </li>
-            <li>Otherwise, <a>reset the range</a> with (<var>node</var>,
-            <var>offset</var>) and (<var>node</var>, <var>offset</var>).
+            <li>Otherwise, <a>set the composed selection range</a> with
+            (<var>node</var>, <var>offset</var>) and
+            (<var>node</var>, <var>offset</var>).
             </li>
           </ol>
         </dd>
@@ -517,9 +529,11 @@
            <li>If [=this=] is <a>empty</a>, throw an {{InvalidStateError}}
            exception and abort these steps.
            </li>
-           <li>Let <var>bp</var> be the [=Range/start=] of [=this=]'s <a>range</a>.
+           <li>Let <var>bp</var> be the [=Range/start=] of [=this=]'s
+           <a>range</a>.
            </li>
-           <li><a>Reset the range</a> with <var>bp</var> and <var>bp</var>.
+           <li><a>Set the composed selection range</a> with <var>bp</var> and
+           <var>bp</var>.
            </li>
          </ol>
           <p class="note">
@@ -542,7 +556,8 @@
           </li>
           <li>Let <var>bp</var> be the [=Range/end=] of [=this=]'s <a>range</a>.
           </li>
-          <li><a>Reset the range</a> with <var>bp</var> and <var>bp</var>.
+          <li><a>Set the composed selection range</a> with <var>bp</var> and
+          <var>bp</var>.
           </li>
         </ol>
         </dd>
@@ -567,15 +582,17 @@
             <var>offset</var>).
             </li>
             <li>If <var>node</var>'s [=tree/root=] is not the same as
-            [=this=]'s <a>range</a>'s [=tree/root=], <a>reset the range</a> with
+            [=this=]'s <a>range</a>'s [=tree/root=],
+            <a>set the composed selection range</a> with
             <var>newFocus</var> and <var>newFocus</var>.
             </li>
             <li>Otherwise, if <var>oldAnchor</var> is [=boundary point/before=]
-            or equal to <var>newFocus</var>, <a>reset the range</a>
+            or equal to <var>newFocus</var>,
+            <a>set the composed selection range</a>
             with <var>oldAnchor</var> and <var>newFocus</var>.
             </li>
-            <li>Otherwise, <a>reset the range</a> with <var>newFocus</var>
-            and <var>oldAnchor</var>.
+            <li>Otherwise, <a>set the composed selection range</a> with
+            <var>newFocus</var> and <var>oldAnchor</var>.
             </li>
 
             <li>If <var>newFocus</var> is [=boundary point/before=]
@@ -618,9 +635,12 @@
             <var>focus</var> be the <a>boundary point</a>
             (<var>focusNode</var>, <var>focusOffset</var>).
             </li>
-            <li>If <var>anchor</var> is [=boundary point/before=]
-            <var>focus</var>, <a>reset the range</a> with <var>anchor</var> and
-            <var>focus</var>. Otherwise, <a>reset the range</a> with
+            <li>If <var>anchorNode</var>'s [=tree/root=] is the same as
+            <var>focusNode</var>'s [=tree/root=] and <var>anchor</var> is
+            [=boundary point/before=] <var>focus</var>,
+            <a>set the composed selection range</a> with
+            <var>anchor</var> and <var>focus</var>. Otherwise,
+            <a>set the composed selection range</a> with
             <var>focus</var> and <var>anchor</var>.
             </li>
             <li>If <var>focus</var> is [=boundary point/before=]
@@ -646,7 +666,8 @@
             <li>Let <var>childCount</var> be the number of [=tree/children=] of
             <var>node</var>.
             </li>
-            <li><a>Reset the range</a> with (<var>node</var>, <code>0</code>)
+            <li><a>Set the composed selection range</a> with
+            (<var>node</var>, <code>0</code>)
             and (<var>node</var>, <var>childCount</var>).
             </li>
             <li>Set [=this=]'s <a>direction</a> to <var>forwards</var>.

--- a/index.html
+++ b/index.html
@@ -113,10 +113,11 @@
       </p>
       <p>
         Each <a>selection</a> can be associated with a single
-        <a href="TODO">composed selection range</a> <dfn>range</dfn>.
-        When there is no <a>range</a> associated with the <a>selection</a>, the
-        selection is <dfn>empty</dfn>. The selection must be initially
-        <a>empty</a>.
+        <a href="TODO">composed range</a> <dfn>composed range</dfn>,
+        which will have an associated <a href="TODO">legacy uncomposed range</a>
+        <dfn>uncomposed range</dfn>. When there is no <a>composed range</a>
+        associated with the <a>selection</a>, the selection is <dfn>empty</dfn>.
+        The selection must be initially <a>empty</a>.
       </p>
       <p class="note">
         A <a>document</a>'s <a>selection</a> is a singleton object associated
@@ -128,23 +129,22 @@
         dev do not. We follow Gecko/WebKit, because it lessens the chance of
         getRangeAt(0) throwing.
       </p>
-      <p>To <dfn>set the composed selection range</dfn> of [=this=], given the
+      <p>To <dfn>set the composed range</dfn> of [=this=], given the
        <a>boundary point</a> <var>start</var> and <a>boundary point</a>
        <var>end</var>, run these steps:
       </p>
       <ol>
-        <li>Let <var>liveRange</var> be a new {{Range/}} object.</li>
+        <li>Let <var>liveRange</var> be a new {{Range}} object.</li>
         <li>[=Range/Set the start=] of <var>liveRange</var> to <var>start</var>.
         </li>
         <li>[=Range/Set the end=] of <var>liveRange</var> to <var>end</var>.
         </li>
         <li>Let <var>composedRange</var> be a new
-        <a href="">composed selection range</a>
-        whose [=Range/start=] is <var>start</var>, [=Range/end=] is
-        <var>end</var> and <var>legacy selection range</var> is
-        <var>liveRange</var>.
+        <a href="TODO">composed range</a> whose [=Range/start=] is
+        <var>start</var>, [=Range/end=] is <var>end</var> and
+        <var>legacy uncomposed range</var> is <var>liveRange</var>.
         </li>
-        <li>Set [=this=]'s <a href="">composed selection range</a> to
+        <li>Set [=this=]'s <a>composed range</a> to
         <var>composedRange</var>.
         </li>
       </ol>
@@ -157,9 +157,9 @@
         without any collapsing logic.
       </p>
       <p>
-        Once a <a>selection</a> is associated with a given <a>range</a>, it
-        must continue to be associated with that same <a>range</a> until this
-        specification requires otherwise.
+        Once a <a>selection</a> is associated with a given
+        <a>composed range</a>, it must continue to be associated with that same
+        <a>composed range</a> until this specification requires otherwise.
       </p>
       <p class="note" data-link-for="Selection">
         For instance, if the DOM changes in a way that changes the range's
@@ -170,40 +170,41 @@
         object, as required elsewhere in this specification.
       </p>
       <p>
-        If the <a>selection</a>'s <a>range</a> is not null and is
+        If the <a>selection</a>'s <a>uncomposed range</a> is not null and is
         [=range/collapsed=], then the caret position must be at that
-        <a>range</a>'s <a>boundary point</a>. When the <a>selection</a> is not
-        [=range/collapsed=], this specification does not define the caret
-        position; user agents should follow platform conventions in deciding
-        whether the caret is at the start of the <a>selection</a>, the end of
-        the <a>selection</a>, or somewhere else.
+        <a>uncomposed range</a>'s <a>boundary point</a>. When the
+        <a>selection</a> is not [=range/collapsed=], this specification does not
+        define the caret position; user agents should follow platform
+        conventions in deciding whether the caret is at the start of the
+        <a>selection</a>, the end of the <a>selection</a>, or somewhere else.
       </p>
       <p>
         Each <a>selection</a> has a <dfn>direction</dfn>: <dfn>forwards</dfn>,
         <dfn>backwards</dfn>, or <dfn>directionless</dfn>. If the user creates
         a <a>selection</a> by indicating first one <a>boundary point</a> of the
-        <a>range</a> and then the other (such as by clicking on one point and
-        dragging to another), and the first indicated <a>boundary point</a> is
-        [=boundary point/after=] the second, then the corresponding
-        <a>selection</a> must initially be <a>backwards</a>. If the first
-        indicated <a>boundary point</a> is [=boundary point/before=] the
-        second, then the corresponding <a>selection</a> must initially be
-        <a>forwards</a>. Otherwise, it must be <a>directionless</a>.
+        <a>composed range</a> and then the other (such as by clicking on one
+        point and dragging to another), and the first indicated
+        <a>boundary point</a> is [=boundary point/after=] the second, then the
+        corresponding <a>selection</a> must initially be <a>backwards</a>.
+        If the first indicated <a>boundary point</a> is
+        [=boundary point/before=] the second, then the corresponding
+        <a>selection</a> must initially be <a>forwards</a>.
+        Otherwise, it must be <a>directionless</a>.
       </p>
       <p>
-        When the <a>selection</a>'s <a>range</a> is mutated by scripts, e.g.
-        via {{Range/selectNode(node)}}, <a>direction</a> of the
+        When the <a>selection</a>'s <a>composed range</a> is mutated by scripts,
+        e.g. via {{Range/selectNode(node)}}, <a>direction</a> of the
         <a>selection</a> must be preserved.
       </p>
       <p>
         Each <a>selection</a> also has an <dfn>anchor</dfn> and a
-        <dfn>focus</dfn>. If the <a>selection</a>'s <a>range</a> is null, its
-        <a>anchor</a> and <a>focus</a> are both null. If the <a>selection</a>'s
-        <a>range</a> is not null and its <a>direction</a> is <a>forwards</a>,
-        its <a>anchor</a> is the <a>range</a>'s legacy selection range's
-        [=range/start=], and its <a>focus</a> is the [=range/end=]. Otherwise,
-        its <a>focus</a> is the [=range/start=] and its <a>anchor</a> is the
-        [=range/end=].
+        <dfn>focus</dfn>. If the <a>selection</a>'s <a>uncomposed range</a> is
+        null, its <a>anchor</a> and <a>focus</a> are both null. If the
+        <a>selection</a>'s <a>uncomposed range</a> is not null and its
+        <a>direction</a> is <a>forwards</a>, its <a>anchor</a> is the
+        <a>uncomposed range</a>'s [=range/start=], and its <a>focus</a> is the
+        [=range/end=]. Otherwise, its <a>focus</a> is the [=range/start=] and
+        its <a>anchor</a> is the [=range/end=].
       </p>
       <p class="note">
         <a>anchor</a> and <a>focus</a> of <a>selection</a> need not to be in
@@ -326,7 +327,7 @@
           <p>
             The attribute must return `"None"` if [=this=] is <a>empty</a> or
             either <a>focus</a> or <a>anchor</a> is not in the [=document
-            tree=], `"Caret"` if [=this=]'s <a>range</a> is
+            tree=], `"Caret"` if [=this=]'s <a>uncomposed range</a> is
             [=range/collapsed=], and `"Range"` otherwise.
           </p>
         </dd>
@@ -350,12 +351,13 @@
             <var>index</var> is not <code>0</code>, or if [=this=] is
             <a>empty</a> or either <a>focus</a> or <a>anchor</a> is not in the
             [=document tree=]. Otherwise, it must return a reference to (not a
-            copy of) [=this=]'s <a>range</a>'s legacy selection range.
+            copy of) [=this=]'s <a>uncomposed range</a>.
           </p>
           <p class="note">
-            Thus subsequent calls of this method returns the same <a>range</a>
-            object if nothing has removed [=this=]'s range in the meantime. In
-            particular, <code>getSelection().getRangeAt(0) ===
+            Thus subsequent calls of this method returns the same
+            <a>uncomposed range</a> object if nothing has removed [=this=]'s
+            range in the meantime. In particular,
+            <code>getSelection().getRangeAt(0) ===
             getSelection().getRangeAt(0)</code> evaluates to <code>true</code>
             if the <a>selection</a> is not <a>empty</a>.
           </p>
@@ -375,31 +377,37 @@
             <li>If <code>rangeCount</code> is not <code>0</code>, abort these
             steps.
             </li>
-            <li>Set [=this=]'s range's legacy selection range to
-             <var>range</var> by a strong reference (not by making a copy).
+            <li>Set [=this=]'s uncomposed range to <var>range</var>
+            by a strong reference (not by making a copy).
+            </li>
+            <li>Set [=this=]'s composed range's [=Range/start=] to
+            <var>range</var>'s start.
+            </li>
+            <li>Set [=this=]'s composed range's [=Range/end=] to
+            <var>range</var>'s end.
             </li>
           </ol>
           <p class="note">
-            Since <a>range</a> is added by reference, subsequent calls to
-            <code>getRangeAt(0)</code> returns the same object, and any changes
-            that a script makes to <a>range</a> after it is added must be
-            reflected in the <a>selection</a>, until something else removes or
-            replaces [=this=]'s <a>range</a>. In particular, the
-            <a>selection</a> will contain <var>b</var> as opposed to
-            <var>a</var> after running the following code: <code>var r =
-            document.createRange(); r.selectNode(a);
+            Since <a>uncomposed range</a> is added by reference, subsequent
+            calls to <code>getRangeAt(0)</code> returns the same object, and any
+            changes that a script makes to <a>uncomposed range</a> after it is
+            added must be reflected in the <a>selection</a>, until something
+            else removes or replaces [=this=]'s <a>uncomposed range</a>.
+            In particular, the <a>selection</a> will contain <var>b</var> as
+            opposed to <var>a</var> after running the following code:
+            <code>var r = document.createRange(); r.selectNode(a);
             getSelection().addRange(r); r.selectNode(b);</code>
           </p>
           <div class="note">
             <p>
               At Step 2, Chrome 58 and Edge 25 do nothing. Firefox 51 gives you
               a multi-range selection. At least they keep the exisiting
-              <a>range</a>.
+              <a>uncomposed range</a>.
             </p>
             <p>
               At Step 3, Chrome 58 and Firefox 51 store a reference, as
               described here. Edge 25 stores a copy. Firefox 51 changes its
-              selection if the <a>range</a> is modified.
+              selection if the <a>uncomposed range</a> is modified.
             </p>
           </div>
         </dd>
@@ -409,7 +417,7 @@
         <dd>
           <p>
             The method must make [=this=] <a>empty</a> by disassociating its
-            <a>range</a> if [=this=]'s <a>range</a>'s legacy selection range is
+            <a>composed range</a> if [=this=]'s <a>uncomposed range</a> is
             <var>range</var>. Otherwise, it must throw a {{NotFoundError}}.
           </p>
         </dd>
@@ -419,7 +427,8 @@
         <dd>
           <p>
             The method must make [=this=] <a>empty</a> by disassociating its
-            <a>range</a> if [=this=] has an associated <a>range</a>.
+            <a>composed range</a> if [=this=] has an associated
+            <a>composed range</a>.
           </p>
         </dd>
         <dt>
@@ -439,8 +448,9 @@
             <li>If [=this=] is <a>empty</a>, return an empty array.
             </li>
             <li>Otherwise, let <var>startNode</var> be [=range/start node=] of
-            the [=range=] associated with [=this=], and let
-            <var>startOffset</var> be [=range/start offset=] of the [=range=].
+            the <a>composed range</a> associated with [=this=], and let
+            <var>startOffset</var> be [=range/start offset=] of the
+            <a>composed range</a>.
             </li>
             <li>While <var>startNode</var> is a [=node=],
             <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and
@@ -457,9 +467,10 @@
                 </li>
               </ol>
             </li>
-            <li>Let <var>endNode</var> be [=range/end node=] of the [=range=]
-            associated with [=this=], and let <var>endOffset</var> be
-            [=range/end offset=] of the [=range=].
+            <li>Let <var>endNode</var> be [=range/end node=] of the
+            <a>composed range</a> associated with [=this=], and let
+            <var>endOffset</var> be [=range/end offset=] of the
+            <a>composed range</a>.
             </li>
             <li>While <var>endNode</var> is a [=node=], <var>endNode</var>'s
             [=tree/root=] is a [=shadow root=], and <var>endNode</var>'s
@@ -506,7 +517,7 @@
             [=shadow-including inclusive ancestor=] of <var>node</var>, abort
             these steps.
             </li>
-            <li>Otherwise, <a>set the composed selection range</a> with
+            <li>Otherwise, <a>set the composed range</a> with
             (<var>node</var>, <var>offset</var>) and
             (<var>node</var>, <var>offset</var>).
             </li>
@@ -533,9 +544,9 @@
            exception and abort these steps.
            </li>
            <li>Let <var>bp</var> be the [=Range/start=] of [=this=]'s
-           <a>range</a>.
+           <a>uncomposed range</a>.
            </li>
-           <li><a>Set the composed selection range</a> with <var>bp</var> and
+           <li><a>Set the composed range</a> with <var>bp</var> and
            <var>bp</var>.
            </li>
          </ol>
@@ -557,9 +568,10 @@
           <li>If [=this=] is <a>empty</a>, throw an {{InvalidStateError}}
           exception and abort these steps.
           </li>
-          <li>Let <var>bp</var> be the [=Range/end=] of [=this=]'s <a>range</a>.
+          <li>Let <var>bp</var> be the [=Range/end=] of [=this=]'s
+          <a>uncomposed range</a>.
           </li>
-          <li><a>Set the composed selection range</a> with <var>bp</var> and
+          <li><a>Set the composed range</a> with <var>bp</var> and
           <var>bp</var>.
           </li>
         </ol>
@@ -585,19 +597,17 @@
             <var>offset</var>).
             </li>
             <li>If <var>node</var>'s [=tree/root=] is not the same as
-            [=this=]'s <a>range</a>'s [=tree/root=],
-            <a>set the composed selection range</a> with
+            [=this=]'s <a>uncomposed range</a>'s [=tree/root=],
+            <a>set the composed range</a> with
             <var>newFocus</var> and <var>newFocus</var>.
             </li>
             <li>Otherwise, if <var>oldAnchor</var> is [=boundary point/before=]
-            or equal to <var>newFocus</var>,
-            <a>set the composed selection range</a>
+            or equal to <var>newFocus</var>, <a>set the composed range</a>
             with <var>oldAnchor</var> and <var>newFocus</var>.
             </li>
-            <li>Otherwise, <a>set the composed selection range</a> with
+            <li>Otherwise, <a>set the composed range</a> with
             <var>newFocus</var> and <var>oldAnchor</var>.
             </li>
-
             <li>If <var>newFocus</var> is [=boundary point/before=]
             <var>oldAnchor</var>, set [=this=]'s <a>direction</a> to
             <a>backwards</a>. Otherwise, set it to <a>forwards</a>.
@@ -638,12 +648,11 @@
             <var>focus</var> be the <a>boundary point</a>
             (<var>focusNode</var>, <var>focusOffset</var>).
             </li>
-            <li>If <var>anchorNode</var>'s [=tree/root=] is the same as
-            <var>focusNode</var>'s [=tree/root=] and <var>anchor</var> is
-            [=boundary point/before=] <var>focus</var>,
-            <a>set the composed selection range</a> with
+            <!-- TODO: use definition of composed before -->
+            <li>If <var>anchor</var> is [=boundary point/before=]
+            <var>focus</var>, <a>set the composed range</a> with
             <var>anchor</var> and <var>focus</var>. Otherwise,
-            <a>set the composed selection range</a> with
+            <a>set the composed range</a> with
             <var>focus</var> and <var>anchor</var>.
             </li>
             <li>If <var>focus</var> is [=boundary point/before=]
@@ -669,7 +678,7 @@
             <li>Let <var>childCount</var> be the number of [=tree/children=] of
             <var>node</var>.
             </li>
-            <li><a>Set the composed selection range</a> with
+            <li><a>Set the composed range</a> with
             (<var>node</var>, <code>0</code>)
             and (<var>node</var>, <var>childCount</var>).
             </li>
@@ -769,9 +778,9 @@
         <dd>
           <p>
             The method must invoke {{Range/deleteContents()}} on [=this=]'s
-            <a>range</a> if [=this=] is not <a>empty</a> and both <a>focus</a>
-            and <a>anchor</a> are in the [=document tree=]. Otherwise the
-            method must do nothing.
+            <a>uncomposed range</a> if [=this=] is not <a>empty</a> and
+            both <a>focus</a> and <a>anchor</a> are in the [=document tree=].
+            Otherwise the method must do nothing.
           </p>
           <p class="note">
             This is the one method that actually mutates the range instead of
@@ -792,21 +801,22 @@
           <p>
             Otherwise, if <var>allowPartialContainment</var> is
             <code>false</code>, the method must return <code>true</code> if and
-            only if [=range/start=] of its <a>range</a> is [=boundary
+            only if [=range/start=] of its <a>uncomposed range</a> is [=boundary
             point/before=] or visually equivalent to the first <a>boundary
             point</a> in the <var>node</var> <strong>and</strong> [=range/end=]
-            of its <a>range</a> is [=boundary point/after=] or visually
-            equivalent to the last <a>boundary point</a> in the
+            of its <a>uncomposed range</a> is [=boundary point/after=] or
+            visually equivalent to the last <a>boundary point</a> in the
             <var>node</var>.
           </p>
           <p>
             If <var>allowPartialContainment</var> is <code>true</code>, the
             method must return <code>true</code> if and only if [=range/start=]
-            of its <a>range</a> is [=boundary point/before=] or visually
-            equivalent to the last <a>boundary point</a> in the <var>node</var>
-            <strong>and</strong> [=range/end=] of its <a>range</a> is
-            [=boundary point/after=] or visually equivalent to the first
-            <a>boundary point</a> in the <var>node</var>.
+            of its <a>uncomposed range</a> is [=boundary point/before=] or
+            visually equivalent to the last <a>boundary point</a> in the
+            <var>node</var> <strong>and</strong> [=range/end=] of its
+            <a>uncomposed range</a> is [=boundary point/after=] or visually
+            equivalent to the first <a>boundary point</a> in the
+            <var>node</var>.
           </p>
         </dd>
         <dt>
@@ -815,8 +825,8 @@
         <dd>
           <p>
             The stringification must return the string, which is the
-            concatenation of the rendered text if there is a [=range=]
-            associated with [=this=].
+            concatenation of the rendered text if there is a
+            <a>uncomposed range</a> associated with [=this=].
           </p>
           <p>
             If the selection is within a <a>textarea</a> or <a>input</a>
@@ -856,7 +866,7 @@
       </div>
       <p>
         All of the members of the {{Selection}} interface are defined in terms
-        of operations on the <code><a>range</a></code> object (if any)
+        of operations on the <code><a>composed range</a></code> object (if any)
         represented by the object. These operations can raise exceptions, as
         defined for the {{Range}} interface; this can therefore result in the
         members of the <a>Selection</a> interface raising exceptions as well,
@@ -970,25 +980,26 @@
       <p>
         When the user agent is to [=replace data=] or [=CharacterData/substring
         data=] on {{CharacterData}}, the user agent must update the
-        <a>range</a> associated with <a>selection</a> of the [=Node/node
-        document=] of the {{CharacterData}} as if it's a <a>live range</a>.
+        <a>composed range</a> and <a>uncomposed range</a> associated with
+        <a>selection</a> of the [=Node/node document=] of the {{CharacterData}}.
       </p>
       <p>
         When the user agent is to split a {{Text}} [=node=], the user agent
-        must update the <a>range</a> associated with <a>selection</a> of the
-        [=Node/node document=] of the {{Text}} as if it's a <a>live range</a>.
+        must update the <a>composed range</a> and <a>uncomposed range</a>
+        associated with <a>selection</a> of the [=Node/node document=] of the
+        {{Text}}.
       </p>
       <p>
         When the user agent is to run steps for <code>normalize()</code>
-        method, the user agent must update the <a>range</a> associated with
-        <a>selection</a> of the [=Node/node document=] of [=this=] as if it's a
-        <a>live range</a>.
+        method, the user agent must update the <a>composed range</a> and
+        <a>uncomposed range</a> associated with <a>selection</a> of the
+        [=Node/node document=] of [=this=].
       </p>
       <p>
         When the user agent is to [=remove=] or [=insert=] a [=node=], the user
-        agent must update the <a>range</a> associated with <a>selection</a> of
-        the [=Node/node document=] of the [=node=] as if it's a <a>live
-        range</a>.
+        agent must update the <a>composed range</a> and <a>uncomposed range</a>
+        associated with <a>selection</a> of the [=Node/node document=] of the
+        [=node=].
       </p>
     </section>
     <section>
@@ -999,15 +1010,15 @@
         The user agent should allow the user to change the <a>selection</a>
         associated with the [=navigable/active document=]. If the user makes
         any modification to a <a>selection</a>, the user agent must create a
-        new <a>range</a> with suitable [=range/start=] and [=range/end=] of the
-        <a>range</a> and associate the <a>selection</a> with this new
-        <a>range</a> (not modify the existing <a>range</a>), and set update
-        <a>selection</a>'s <a>direction</a> to <a>forwards</a> if the
-        [=range/start=] is [=boundary point/before=] or equal to the
-        [=range/end=], <a>backwards</a> if if the [=range/end=] is [=boundary
-        point/before=] the [=range/start=], or <a>directionless</a> if the
-        [=range/start=] and the [=range/end=] cannot be ordered due to the
-        platform convention.
+        new <a>composed range</a> with suitable [=range/start=] and
+        [=range/end=] of the <a>composed range</a> and associate the
+        <a>selection</a> with this new <a>composed range</a> (not modify the
+        existing <a>composed range</a>), and set update <a>selection</a>'s
+        <a>direction</a> to <a>forwards</a> if the [=range/start=] is
+        [=boundary point/before=] or equal to the [=range/end=],
+        <a>backwards</a> if if the [=range/end=] is [=boundary point/before=]
+        the [=range/start=], or <a>directionless</a> if the [=range/start=] and
+        the [=range/end=] cannot be ordered due to the platform convention.
       </p>
       <p>
         The user agent must not make a <a>selection</a> <a>empty</a> if it was
@@ -1049,8 +1060,9 @@
           <code><dfn data-dfn-type="event">selectionchange</dfn></code> event
         </h3>
         <p>
-          When the <a>selection</a> is dissociated with its <a>range</a>,
-          associated with a new <a>range</a>, or the associated <a>range</a>'s
+          When the <a>selection</a> is dissociated with its <a>composed range</a>,
+          associated with a new <a>composed range</a>, or the associated
+          <a>composed range</a> or <a>uncomposed range</a>'s
           <a>boundary point</a> is mutated either by the user or the content
           script, the user agent must <a>schedule a selectionchange event</a>
           on <a>document</a>.

--- a/index.html
+++ b/index.html
@@ -133,26 +133,29 @@
        <var>end</var>, run these steps:
       </p>
       <ol>
-       <li>Let <var>liveRange</var> be a new {{Range/}} object.</li>
-       <li>[=Range/Set the start=] of <var>liveRange</var> to <var>start</var>.
-       </li>
-       <li>[=Range/Set the end=] of <var>liveRange</var> to <var>end</var>.</li>
-       <li>Let <var>composedRange</var> be a new
-       <a href="">composed selection range</a>
-       whose [=Range/start=] is <var>start</var>, [=Range/end=] is
-       <var>end</var> and <var>legacy selection range</var> is
-       <var>liveRange</var>.</li>
-       <p class="note">
-        While the above steps might look identical, <var>liveRange</var> and
+        <li>Let <var>liveRange</var> be a new {{Range/}} object.</li>
+        <li>[=Range/Set the start=] of <var>liveRange</var> to <var>start</var>.
+        </li>
+        <li>[=Range/Set the end=] of <var>liveRange</var> to <var>end</var>.
+        </li>
+        <li>Let <var>composedRange</var> be a new
+        <a href="">composed selection range</a>
+        whose [=Range/start=] is <var>start</var>, [=Range/end=] is
+        <var>end</var> and <var>legacy selection range</var> is
+        <var>liveRange</var>.
+        </li>
+        <li>Set [=this=]'s <a href="">composed selection range</a> to
+        <var>composedRange</var>.
+        </li>
+      </ol>
+      <p class="note">
+        While the steps 2-3 and 4 might look identical, <var>liveRange</var> and
         <var>composedRange</var> could end up in very different states. The
         <var>liveRange</var> follows [=Range/set the start=] and
         [=Range/set the end=] algorithms, which will collapse in cross-root
         cases. On the other hand, <var>composedRange</var> is set directly
         without any collapsing logic.
-       </p>
-       <li>Set [=this=]'s <a href="">composed selection range</a> to
-       <var>composedRange</var>.</li>
-     </ol>
+      </p>
       <p>
         Once a <a>selection</a> is associated with a given <a>range</a>, it
         must continue to be associated with that same <a>range</a> until this


### PR DESCRIPTION
The goal of this PR is to add the definitions necessary so the getComposedRanges() API can access a composed live range's endpoints that might cross shadow boundaries instead of accessing the legacy uncomposed live range, which is scoped to be contained within one root only.

This specification is aligned with the currently shipped getComposedRanges() in Webkit and Gecko (behind a flag). It only adds definitions and references; it does not change the structure of any existing user-facing API.

Note: This PR is not ready to merge, but can be reviewed. It depends on the definitions "composed live range" and "cached live range", being specced at: https://github.com/whatwg/dom/pull/1342
The Editing WG issue discussing this change is: https://github.com/w3c/selection-api/issues/2

To summarize, this spec PR changes:

1. Each selection can be associated with a single composed live range.
Most of the existing Selection API functions will refer to the composed live range's cached live range to make sure we are backward compatible. This includes updating definitions for anchor/focus, getRangeAt(0), addRange(), removeRange(), etc. However, for getComposedRanges(), we will refer to the composed live range's endpoints directly.

2. Add "reset the range" algorithm
We add a new "reset the range" of this selection algorithm, which is called by collapse(), collapseToStart(), collapseToEnd(), extend(), setBaseAndExtent(), selectAllChildren(). This will make sure to create and set the composed live range and its cached live range, and call {{Range}}'s "set the start/end" algorithm.

For normative changes, the following tasks have been completed:
 * [x] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
   * [x] WebKit: Positive (https://github.com/mozilla/standards-positions/issues/1055)
   * [x] Chromium: Positive
   * [x] Gecko: Positive (https://github.com/WebKit/standards-positions/issues/376)

 * [x] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=216325)
   * [x] Chromium (https://issues.chromium.org/issues/40286116)
   * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1430308)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dizhang168/selection-api/pull/345.html" title="Last updated on Mar 28, 2025, 11:47 PM UTC (c58cfb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/345/04da02f...dizhang168:c58cfb1.html" title="Last updated on Mar 28, 2025, 11:47 PM UTC (c58cfb1)">Diff</a>