### PR TITLE
Set "has scheduled selectionchange event" to true

### DIFF
--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,7 @@
             event</a> is true, abort these steps.
             </li>
             <li>Set <var>target</var>'s <a>has scheduled selectionchange
-            event</a> to true
+            event</a> to true.
             </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to

--- a/index.html
+++ b/index.html
@@ -1046,6 +1046,9 @@
             <li>If <var>target</var>'s <a>has scheduled selectionchange
             event</a> is true, abort these steps.
             </li>
+            <li>Set <var>target</var>'s <a>has scheduled selectionchange
+            event</a> to true
+            </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to
               <a>fire a selectionchange event</a> on <var>target</var>.


### PR DESCRIPTION
This field was never set to true and probably missed before scheduling the task.

Fixes #338

<!-- Please fill in the sections below when making normative changes. Feel free to remove the sections when only making non-normative changes. -->

For normative changes, the following tasks have been completed:
 * [ ] Editing WG resolution on the proposed changes, with at least two implementers participating and not objecting:
   * [ ] WebKit
   * [ ] Chromium
   * [ ] Gecko

 * [ ] For browsers that are shipping the feature, implementation bugs are filed for the proposed changes (link to bug, or write "Not Implementing"):
   * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
   * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
   * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TimvdLippe/selection-api/pull/356.html" title="Last updated on Apr 23, 2026, 6:39 PM UTC (2890f0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/356/04da02f...TimvdLippe:2890f0c.html" title="Last updated on Apr 23, 2026, 6:39 PM UTC (2890f0c)">Diff</a>