### PR TITLE
Fix selection.modify() to use resolved text direction instead of inline base direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,7 +681,7 @@
         <dt>
           <dfn>modify()</dfn> method
         </dt>
-        <dd data-cite="css-writing-modes-4">
+        <dd data-cite="css-writing-modes-4 UAX9">
           <p>
             The method must follow these steps:
           </p>
@@ -707,13 +707,13 @@
             <a>forwards</a>.
             </li>
             <li>If <var>direction</var> is <a>ASCII case-insensitive</a> match
-            with "right" and [=inline base direction=] of <a>this</a>
+            with "right" and the <a>resolved text direction</a> at <a>this</a>
             <a>selection</a>'s <a>focus</a> is <a data-xref-type="css-value"
             data-xref-for="direction">ltr</a>, set
             <var>effectiveDirection</var> to <a>forwards</a>.
             </li>
             <li>If <var>direction</var> is <a>ASCII case-insensitive</a> match
-            with "left" and [=inline base direction=] of <a>this</a>
+            with "left" and the <a>resolved text direction</a> at <a>this</a>
             <a>selection</a>'s <a>focus</a> is <a data-xref-type="css-value"
             data-xref-for="direction">rtl</a>, set
             <var>effectiveDirection</var> to <a>forwards</a>.
@@ -731,6 +731,24 @@
             selection by <var>granularity</var>.
             </li>
           </ol>
+          <p>
+            The <dfn>resolved text direction</dfn> at a <a>boundary point</a>
+            is <a data-xref-type="css-value"
+            data-xref-for="direction">ltr</a> if the <a
+            href="https://www.unicode.org/reports/tr9/#BD3">embedding
+            direction</a> ([[!UAX9]] BD3) of the character at that position
+            is L, and <a data-xref-type="css-value"
+            data-xref-for="direction">rtl</a> if the <a
+            href="https://www.unicode.org/reports/tr9/#BD3">embedding
+            direction</a> is R.
+          </p>
+          <p class="note">
+            At a bidi boundary—where adjacent characters have different
+            embedding directions—user agents may use additional context
+            (such as caret affinity based on the direction of cursor
+            movement) to determine which character's embedding direction
+            to use.
+          </p>
           <p class="note">
             We need to more precisely define what it means to extend or move
             selection by each granularity.


### PR DESCRIPTION
Steps 7–8 of `Selection.modify()` use the **inline base direction** (paragraph-level CSS `direction`) to map `"left"`/`"right"` to forwards/backwards. This is wrong when the caret is inside a bidi run with a different direction.

```html
<p dir="ltr">Hello שלום world</p>
```

When the caret is inside "שלום" (an RTL run) and the user presses the Right arrow, the current spec maps Right to forwards, and moves the caret visually to the left. This is incorrect. 

The spec should instead use the resolved text direction at the caret (rtl), which maps Right to backwards and moves the caret visually to the right.

**Fix:** Replace "inline base direction" with "resolved text direction at the focus" (bidi embedding level per [UAX#9](https://www.unicode.org/reports/tr9/): even = LTR, odd = RTL).

**Browser behavior:** Firefox and Safari already use resolved text direction. Chromium currently matches the spec text; a [fix is in progress](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Editing/bidi-visual-order-caret-movement-explainer.md). This change aligns the spec with majority interoperable behavior.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sambandaru/selection-api/pull/357.html" title="Last updated on Jun 9, 2026, 10:44 AM UTC (5ec9fcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/selection-api/357/bf1dad0...sambandaru:5ec9fcd.html" title="Last updated on Jun 9, 2026, 10:44 AM UTC (5ec9fcd)">Diff</a>